### PR TITLE
Pin images to specific release

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,15 @@
 ---
 services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8
+    container_name: ClickHouse
+    ports: ["8123:8123"]
+
   mssql:
     build:
       context: .
       dockerfile: dockerfiles/mssql.Dockerfile
-    image: sql-learning-materials/mssql
+    image: sql-learning-materials/mssql:2022
     container_name: SQL-Server
     environment:
       ACCEPT_EULA: "Y"
@@ -22,17 +27,12 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/postgres.Dockerfile
-    image: sql-learning-materials/postgres
+    image: sql-learning-materials/postgres:16.2
     container_name: PostgreSQL
     environment:
       POSTGRES_PASSWORD: Test@12345
       POSTGRES_USER: postgres
     ports: ["5432:5432"]
-
-  clickhouse:
-    image: clickhouse/clickhouse-server:24.8
-    container_name: ClickHouse
-    ports: ["8123:8123"]
 
   metabase:
     image: metabase/metabase:latest

--- a/dockerfiles/mssql.Dockerfile
+++ b/dockerfiles/mssql.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2022-latest
+FROM mcr.microsoft.com/mssql/server:2022-CU12-GDR1-ubuntu-22.04
 ENV SA_PASSWORD="Test@12345"
 
 ###

--- a/dockerfiles/postgres.Dockerfile
+++ b/dockerfiles/postgres.Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres
+FROM postgres:16.2
 
 ###
 # This expects some files to exist at the locations given below. The


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Pin Docker images to specific versions in the docker-compose.yaml file to ensure consistent and reliable builds by specifying exact image tags for ClickHouse, MSSQL, and PostgreSQL services.

Build:
- Pin Docker images to specific versions in the docker-compose.yaml file to ensure consistent builds.

<!-- Generated by sourcery-ai[bot]: end summary -->