### PR TITLE
Add profile attributes to Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ After installing the pre-requisites and cloning this repo, just run the `resourc
 ```bash
 poetry install --sync  # --with dev,test,docs
 python -m resources
-docker compose up --detach
+docker compose --profile build up --detach
 mkdocs build
 mkdocs serve
 docker compose down --volumes  # When you're finished

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,49 +1,54 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json
 ---
+# profiles:
+#   `skip`: Skip the service
+#   `build`: Build the service
+
 services:
   clickhouse:
     image: clickhouse/clickhouse-server:24.8
     container_name: ClickHouse
     ports: ["8123:8123"]
+    profiles: ["skip"]
 
   mssql:
-    build:
-      context: .
-      dockerfile: dockerfiles/mssql.Dockerfile
+    build: { context: ".", dockerfile: "dockerfiles/mssql.Dockerfile" }
     image: sql-learning-materials/mssql:2022
     container_name: SQL-Server
+    ports: ["1433:1433"]
+    profiles: ["build"]
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_PID: Developer
-    ports: ["1433:1433"]
 
   mysql:
     image: mysql:8.4.2
     container_name: MySQL
+    ports: ["3306:3306"]
+    profiles: ["skip"]
     environment:
       MYSQL_ROOT_PASSWORD: Test@12345
-    ports: ["3306:3306"]
 
   postgres:
-    build:
-      context: .
-      dockerfile: dockerfiles/postgres.Dockerfile
+    build: { context: ".", dockerfile: "dockerfiles/postgres.Dockerfile" }
     image: sql-learning-materials/postgres:16.2
     container_name: PostgreSQL
+    ports: ["5432:5432"]
+    profiles: ["build"]
     environment:
       POSTGRES_PASSWORD: Test@12345
       POSTGRES_USER: postgres
-    ports: ["5432:5432"]
 
   metabase:
     image: metabase/metabase:latest
     container_name: Metabase
     hostname: metabase
+    ports: ["3000:3000"] # http://localhost:3000/
+    profiles: ["skip"]
+    depends_on: ["mssql", "postgres"]
+    environment:
+      MB_DB_FILE: /metabase-data/metabase.db
     volumes:
       - type: bind
         source: ./dockerfiles/metabase-data
         target: /metabase-data/
-    # http://localhost:3000/
-    ports: ["3000:3000"]
-    environment:
-      MB_DB_FILE: /metabase-data/metabase.db
-    depends_on: ["mssql", "postgres"]


### PR DESCRIPTION
## Summary by Sourcery

Introduce Docker Compose profiles to manage service build and skip behavior, and update documentation accordingly.

Build:
- Add profile attributes to Docker Compose services to control which services are built or skipped.

Documentation:
- Update README.md to include instructions for using Docker Compose profiles.