### PR TITLE
Handle division by zero in funnel analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16.2-teal.svg)](https://www.postgresql.org/download/)
 [![ClickHouse](https://img.shields.io/badge/ClickHouse-24.8-teal.svg)](https://clickhouse.com/docs/en/install)
 [![SQLite](https://img.shields.io/badge/SQLite-3.45-teal.svg)](https://www.sqlite.org/index.html)
-[![DuckDB](https://img.shields.io/badge/DuckDB-1.0-teal.svg)](https://duckdb.org/)
+[![DuckDB](https://img.shields.io/badge/DuckDB-1.1-teal.svg)](https://duckdb.org/)
 
 </div>
 


### PR DESCRIPTION
Also uses some nicer function chaining, inspired by @dmcmurchy's solution in #44

Resolves #44

## Summary by Sourcery

Fixes a division by zero error in funnel analytics by adding a check for zero values in the denominator when calculating step and total rates. Also, it updates the DuckDB version badge in the README.

Bug Fixes:
- Fixes a division by zero error when calculating step and total rates in funnel analytics by adding a check for zero values in the denominator.

Enhancements:
- Uses if() instead of coalesce() to handle zero values in the denominator when calculating step and total rates.