### PR TITLE
Align uv versions across files

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -23,8 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-        with: { version: "0.6.5", enable-cache: true }
+        with:
+          version: "0.6.12" # reminder: keep aligned with the pre-commit hooks
+          enable-cache: true
       - uses: actions/setup-python@v5
-        with: { python-version: 3.11, python-version-file: "pyproject.toml" }
+        with:
+          python-version: 3.11
+          python-version-file: "pyproject.toml"
       - run: uv sync --group docs
       - run: uv run mkdocs gh-deploy --force

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: check-ast
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.6.12
+    rev: 0.6.12 # reminder: keep aligned with the GitHub actions
     hooks:
       - id: uv-lock
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
+[![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![Python](https://img.shields.io/badge/Python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
 [![Docker](https://img.shields.io/badge/Docker-24.0.5-blue.svg)](https://www.docker.com/)
 [![GitHub last commit](https://img.shields.io/github/last-commit/Bilbottom/sql-learning-materials)](https://shields.io/badges/git-hub-last-commit-by-committer)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dev = [
     "coverage-badge>=1.1.0",
     "pre-commit>=4.1.0",
 ]
+test = [
+    "pytest>=8.3.5",
+    "pytest-cov>=6.0.0",
+]
 docs = [
     "markdown-callouts>=0.4.0",
     "mdx-truly-sane-lists>=1.3",
@@ -30,10 +34,10 @@ docs = [
     "mkdocs-callouts>=1.16.0",
     "mkdocs-material>=9.6.7",
 ]
-test = [
-    "pytest>=8.3.5",
-    "pytest-cov>=6.0.0",
-]
+
+
+[tool.setuptools.packages.find]
+include = ["src"]
 
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -180,14 +180,14 @@ wheels = [
 
 [[package]]
 name = "db-query-profiler"
-version = "0.0.6"
+version = "0.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/f5/2d453e514eafb03623f4f67b8b861567e92ae1ec8c4d762005d48c7dca4a/db_query_profiler-0.0.6.tar.gz", hash = "sha256:25097bdb43341c1a43aa782c6992c4397d1f752645b100df125cbda77e593ded", size = 6598 }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/38/7a28d8e76872408fe43134e2363bf20d577d3c1117ecb0576f4e3f49cad2/db_query_profiler-0.0.7.tar.gz", hash = "sha256:a4fce20b3fa94cbdaa272da51830bcd30a0bb2b7155d235de4c8be4f46e8b4a9", size = 7303 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/9a/c521dc083b7571944b115ffdca1681d8bb1bef4c28493c557cd098fbec2e/db_query_profiler-0.0.6-py3-none-any.whl", hash = "sha256:5f49fa357c070ffb07d250207c4d2613ca71880e27ccf842fda664e1727b8c70", size = 7227 },
+    { url = "https://files.pythonhosted.org/packages/93/86/cde888f21e3f3dae7acd6fc50dab55c5bf13fefedeb7d7a8def7b5e1a2a5/db_query_profiler-0.0.7-py3-none-any.whl", hash = "sha256:704d8cec876d3664c45729e4d5b1ba2ed2bd6d9361eb0519f4011d6713da2852", size = 7377 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Align uv versions across project files and update project configuration

Enhancements:
- Update uv version to 0.6.12 consistently across GitHub Actions, pre-commit hooks, and documentation

CI:
- Ensure uv version consistency in GitHub Actions workflow

Chores:
- Update Python version badge to use 3.11+ instead of specific 3.11 version
- Reorganize pyproject.toml dependencies section