### PR TITLE
Only use one Python version specifier in CI

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -28,7 +28,6 @@ jobs:
           enable-cache: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
           python-version-file: "pyproject.toml"
-      - run: uv sync --group docs
+      - run: uv sync --no-default-groups --group docs
       - run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update GitHub Actions workflow to use Python version from pyproject.toml and modify uv sync command to only install documentation dependencies